### PR TITLE
check for hashes in localstorage

### DIFF
--- a/plugins/dao.js
+++ b/plugins/dao.js
@@ -103,9 +103,16 @@ export default (context, inject) => {
         }
       },
       async getIpfsContent (hash) {
-        await new Promise(resolve => setTimeout(resolve, 1000))
-        const data = await fetch(process.env.ipfsExplorer + '/ipfs/' + hash)
-        return data.json()
+        if (localStorage.getItem(hash) === null) {
+          const response = await fetch(process.env.ipfsExplorer + '/ipfs/' + hash)
+          if (response.ok) {
+            const json = await response.json()
+            localStorage.setItem(hash, JSON.stringify(json))
+            return json
+          }
+        } else {
+          return JSON.parse(localStorage.getItem(hash))
+        }
       }
     }
   })


### PR DESCRIPTION
# Before the caching
before the caching of ipfs hashes, the total of requests was around `111` when going from the home page to the proposal page.

now when you go from a single proposal page back to the overview, the total amount jumps up from `174` (111+ 63 requests from the single proposal page) to `285`!

# After the caching
when you go from the home page to the proposal page for the first time, it has to get the ipfs hashes, so the amount of requests will be `117`. 

But now they are cached inside of the localstorage, so when we go to a single proposal page, the amount will be `179` (117 + 62 requests). Now when you go back to the overview from the single proposal page, the total amount will be `187`. Compared with the previous end result that is quite the improvement.

Feel free to ask questions or give pointers on where it may be improved.
