### PR TITLE
add word wrap for hyperlinks that are too long.

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -12,6 +12,7 @@ html {
 
 a {
   outline: 0;
+  word-wrap: break-word;
 }
 
 .notification {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24189525/182336308-572db1de-6343-4eea-84a6-061ed09a7dfb.png)

just noticed that links overflow out of the div when they are too long. added a css rule `word-wrap: break-word` that should fix it for all hyperlinks
![image](https://user-images.githubusercontent.com/24189525/182336767-46470ebf-a0a1-411b-93a6-42c48acd5f6c.png)
