### PR TITLE
Added Telegram link to navbar and dates for proposals

### DIFF
--- a/components/NavBar.vue
+++ b/components/NavBar.vue
@@ -57,6 +57,11 @@
                 Rewards
               </nuxt-link>
             </div>
+            <div @click="mobileMenu = false">
+              <a class="navbar-item" href="https://t.me/EffectNetworkDAO" target="_blank">
+                Telegram
+              </a>
+            </div>
           </div>
           <div class="navbar-end">
               <div class="pt-0 navbar-item">

--- a/components/Proposals.vue
+++ b/components/Proposals.vue
@@ -33,6 +33,9 @@
               <small class="mr-1">&nbsp;by <nuxt-link :to="'/account/'+proposal.author">{{ proposal.author }}</nuxt-link></small>
               <small><span v-for="(pay, index) in proposal.pay" :key="index"><span v-if="index > 0">,</span> {{ $wallet.formatNumber(parseInt(pay.field_0.quantity)) }} EFX</span></small>
             </div>
+            <div class="has-text-weight-light">
+              <small>Created On: {{proposal.pay[0]["field_1"].split("T")[0]}}</small>
+            </div>
           </div>
           <div class="column is-2 has-text-left-mobile has-text-right-desktop has-text-left-tablet">
             <div class="tag" :class="{'is-success': proposal.status == 'ACTIVE', 'is-warning': proposal.status == 'DRAFT', 'is-link': proposal.status == 'PENDING', 'is-dark': proposal.status == 'CLOSED'}">{{ proposal.status }}</div>


### PR DESCRIPTION
Resolves #141, resolves #142, resolves #143 

There is a slight caveat in the dates for the proposals. The dates that are displayed are the dates in which the proposals were paid for and not exactly when they went into the "Active" state.  